### PR TITLE
test in_tail: relax timeout limitation to receive events

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -229,7 +229,7 @@ class TailInputTest < Test::Unit::TestCase
       d = create_driver(config)
       msg = 'test' * 2000 # in_tail reads 8192 bytes at once.
 
-      d.run(expect_emits: num_events, timeout: 1) do
+      d.run(expect_emits: num_events, timeout: 3) do
         File.open("#{TMP_DIR}/tail.txt", "ab") {|f|
           f.puts msg
           f.puts msg


### PR DESCRIPTION
It will fix the following error on windows.

  Failure: test_emit_with_read_lines_limit[flat 10](TailInputTest::singleline)
  C:/projects/fluentd/test/plugin/test_in_tail.rb:243:in `test_emit_with_read_lines_limit'
       240:       end
       241:
       242:       events = d.events
    => 243:       assert_equal(true, events.length > 0)
       244:       assert_equal({"message" => msg}, events[0][2])
       245:       assert_equal({"message" => msg}, events[1][2])
       246:       assert num_events <= d.emit_count
  <true> expected but was
  <false>

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

**Docs Changes**:

**Release Note**: 
