### PR TITLE
test in_tail: use safer method to cleanup

### DIFF
--- a/lib/fluent/plugin/formatter_ltsv.rb
+++ b/lib/fluent/plugin/formatter_ltsv.rb
@@ -27,14 +27,14 @@ module Fluent
 
       config_param :delimiter, :string, default: "\t".freeze
       config_param :label_delimiter, :string, default: ":".freeze
+      config_param :replacement, :string, default: " ".freeze
       config_param :add_newline, :bool, default: true
 
-      # TODO: escaping for \t in values
       def format(tag, time, record)
         formatted = ""
         record.each do |label, value|
           formatted << @delimiter if formatted.length.nonzero?
-          formatted << "#{label}#{@label_delimiter}#{value}"
+          formatted << "#{label}#{@label_delimiter}#{value.to_s.gsub(@delimiter, @replacement)}"
         end
         formatted << @newline if @add_newline
         formatted

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -6,6 +6,7 @@ require 'fluent/system_config'
 require 'net/http'
 require 'flexmock/test_unit'
 require 'timecop'
+require 'tmpdir'
 require 'securerandom'
 
 class TailInputTest < Test::Unit::TestCase

--- a/test/test_formatter.rb
+++ b/test/test_formatter.rb
@@ -193,7 +193,7 @@ module FormatterTest
       @formatter.configure({})
       formatted = @formatter.format(tag, @time, record_with_tab)
 
-      assert_equal("message:awe some\tgreeting:hello \n", formatted)
+      assert_equal("message:awe some\tgreeting:hello #{@newline}", formatted)
     end
 
     def test_format_suppresses_tab_custom_replacement
@@ -202,7 +202,7 @@ module FormatterTest
       )
       formatted = @formatter.format(tag, @time, record_with_tab)
 
-      assert_equal("message:aweXsome\tgreeting:helloX\n", formatted)
+      assert_equal("message:aweXsome\tgreeting:helloX#{@newline}", formatted)
     end
 
     def test_format_suppresses_custom_delimiter
@@ -212,7 +212,7 @@ module FormatterTest
       )
       formatted = @formatter.format(tag, @time, record)
 
-      assert_equal("message=a esomewgreeting=hello\n", formatted)
+      assert_equal("message=a esomewgreeting=hello#{@newline}", formatted)
     end
   end
 

--- a/test/test_formatter.rb
+++ b/test/test_formatter.rb
@@ -184,6 +184,36 @@ module FormatterTest
 
       assert_equal("message=awesome,greeting=hello#{@newline}", formatted)
     end
+
+    def record_with_tab
+      {'message' => "awe\tsome", 'greeting' => "hello\t"}
+    end
+
+    def test_format_suppresses_tab
+      @formatter.configure({})
+      formatted = @formatter.format(tag, @time, record_with_tab)
+
+      assert_equal("message:awe some\tgreeting:hello \n", formatted)
+    end
+
+    def test_format_suppresses_tab_custom_replacement
+      @formatter.configure(
+        'replacement'      => 'X',
+      )
+      formatted = @formatter.format(tag, @time, record_with_tab)
+
+      assert_equal("message:aweXsome\tgreeting:helloX\n", formatted)
+    end
+
+    def test_format_suppresses_custom_delimiter
+      @formatter.configure(
+        'delimiter'       => 'w',
+        'label_delimiter' => '=',
+      )
+      formatted = @formatter.format(tag, @time, record)
+
+      assert_equal("message=a esomewgreeting=hello\n", formatted)
+    end
   end
 
   class CsvFormatterTest < ::Test::Unit::TestCase


### PR DESCRIPTION
This PR aims to fix in_tail test cases on Windows.

On Windows, when the file or directory is removed and created
frequently, there is a case that creating file or directory will fail.
This situation is caused by pending file or directory deletion which
is mentioned on win32 API document.

ref. https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#files

As a workaround, execute rename and remove method.

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

**Docs Changes**:

**Release Note**: 
