### PR TITLE
Backport(v1.16): test_in_tail: add wait to detect rotation (#4874)

### DIFF
--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -1611,6 +1611,7 @@ class TailInputTest < Test::Unit::TestCase
 
       cleanup_file("#{@tmp_dir}/tail.txt")
       waiting(20) { sleep 0.1 until Dir.glob("#{@tmp_dir}/*.txt").size == 0 } # Ensure file is deleted on Windows
+      waiting(5) { sleep 0.1 until d.logs.last.include?("detected rotation") }
       waiting(5) { sleep 0.1 until d.instance.instance_variable_get(:@tails).keys.size <= 0 }
 
       assert_equal(


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Backport #4874
Fixes #4079

**What this PR does / why we need it**: 
For reasons such as the load on the CI execution environment, looks like that rotation detection is delayed and the test does not execute as expected.

For this reason, this patch adds a wait to ensure to detect the rotation.

Before the patch was introduced, tests failed about once every 20 to 50 times.
After, the test was successful  500 consecutive times.

**Docs Changes**:

**Release Note**: 
