### PR TITLE
Backport(v1.16): Add fiddle as dependency gem for Ruby 3.5 on Windows (#4869)

### DIFF
--- a/fluentd.gemspec
+++ b/fluentd.gemspec
@@ -44,6 +44,9 @@ Gem::Specification.new do |gem|
     gem.add_runtime_dependency("win32-ipc", ["~> 0.7.0"])
     gem.add_runtime_dependency("win32-event", ["~> 0.6.3"])
     gem.add_runtime_dependency("certstore_c", ["~> 0.1.7"])
+
+    # gems that aren't default gems as of Ruby 3.5
+    gem.add_runtime_dependency("fiddle", ["~> 1.1"])
   end
 
   gem.add_development_dependency("rake", ["~> 13.0"])


### PR DESCRIPTION
<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Backport #4869
Fixes #

**What this PR does / why we need it**: 
Since Ruby 3.5, `fiddle` gem was marked as bundled gem.
https://github.com/ruby/ruby/commit/10ecdeb4665cbc061f80cc26c5456ff124703d89

This patch will fix following warning on Windows Ruby 3.4 and fix load error on Windows Ruby 3.5:

```
C:/hostedtoolcache/windows/Ruby/3.4.2/x64/lib/ruby/gems/3.4.0/gems/serverengine-2.4.0/lib/serverengine/winsock.rb:21: warning: fiddle/import is found in fiddle, which will no longer be part of the default gems starting from Ruby 3.5.0.
You can add fiddle to your Gemfile or gemspec to silence this warning.
```

FYI)
`fiddle` has been used in

https://github.com/fluent/fluentd/blob/f1f0bb2474ed8d4f7b6011a321a2b93e3b1dd9cb/lib/fluent/win32api.rb#L21-L22


**Docs Changes**:

**Release Note**: 
