### PR TITLE
rubocop: reduce redundant block.call for performance

### DIFF
--- a/lib/fluent/compat/output.rb
+++ b/lib/fluent/compat/output.rb
@@ -404,14 +404,14 @@ module Fluent
         end
       end
 
-      def detach_process(&block)
+      def detach_process
         log.warn "detach_process is not supported in this version. ignored."
-        block.call
+        yield
       end
 
-      def detach_multi_process(&block)
+      def detach_multi_process
         log.warn "detach_process is not supported in this version. ignored."
-        block.call
+        yield
       end
     end
 
@@ -541,14 +541,14 @@ module Fluent
         end
       end
 
-      def detach_process(&block)
+      def detach_process
         log.warn "detach_process is not supported in this version. ignored."
-        block.call
+        yield
       end
 
-      def detach_multi_process(&block)
+      def detach_multi_process
         log.warn "detach_process is not supported in this version. ignored."
-        block.call
+        yield
       end
     end
 
@@ -698,14 +698,14 @@ module Fluent
         end
       end
 
-      def detach_process(&block)
+      def detach_process
         log.warn "detach_process is not supported in this version. ignored."
-        block.call
+        yield
       end
 
-      def detach_multi_process(&block)
+      def detach_multi_process
         log.warn "detach_process is not supported in this version. ignored."
-        block.call
+        yield
       end
 
       # Original TimeSlicedOutput#emit doesn't call #format_stream

--- a/lib/fluent/config/element.rb
+++ b/lib/fluent/config/element.rb
@@ -127,10 +127,10 @@ module Fluent
         super
       end
 
-      def check_not_fetched(&block)
+      def check_not_fetched
         each_key { |key|
           if @unused.include?(key)
-            block.call(key, self)
+            yield(key, self) if block_given?
           end
         }
         @elements.each { |e|

--- a/lib/fluent/event.rb
+++ b/lib/fluent/event.rb
@@ -106,8 +106,8 @@ module Fluent
       end
     end
 
-    def each(unpacker: nil, &block)
-      block.call(@time, @record)
+    def each(unpacker: nil)
+      yield(@time, @record)
       nil
     end
   end
@@ -189,11 +189,11 @@ module Fluent
       MultiEventStream.new(@time_array.slice(index, num), @record_array.slice(index, num))
     end
 
-    def each(unpacker: nil, &block)
+    def each(unpacker: nil)
       time_array = @time_array
       record_array = @record_array
       for i in 0..time_array.length-1
-        block.call(time_array[i], record_array[i])
+        yield(time_array[i], record_array[i])
       end
       nil
     end
@@ -253,10 +253,10 @@ module Fluent
       MultiEventStream.new(@unpacked_times.slice(index, num), @unpacked_records.slice(index, num))
     end
 
-    def each(unpacker: nil, &block)
+    def each(unpacker: nil)
       ensure_unpacked!(unpacker: unpacker)
       @unpacked_times.each_with_index do |time, i|
-        block.call(time, @unpacked_records[i])
+        yield(time, @unpacked_records[i])
       end
       nil
     end

--- a/lib/fluent/log.rb
+++ b/lib/fluent/log.rb
@@ -309,11 +309,11 @@ module Fluent
       yield
     end
 
-    def trace(*args, &block)
+    def trace(*args)
       return if @level > LEVEL_TRACE
       type = log_type(args)
       return if skipped_type?(type)
-      args << block.call if block
+      args << yield if block_given?
       time, msg = event(:trace, args)
       return if time.nil?
       puts [@color_trace, @formatter.call(type, time, LEVEL_TRACE, msg), @color_reset].join
@@ -331,11 +331,11 @@ module Fluent
       yield
     end
 
-    def debug(*args, &block)
+    def debug(*args)
       return if @level > LEVEL_DEBUG
       type = log_type(args)
       return if skipped_type?(type)
-      args << block.call if block
+      args << yield if block_given?
       time, msg = event(:debug, args)
       return if time.nil?
       puts [@color_debug, @formatter.call(type, time, LEVEL_DEBUG, msg), @color_reset].join
@@ -352,11 +352,11 @@ module Fluent
       yield
     end
 
-    def info(*args, &block)
+    def info(*args)
       return if @level > LEVEL_INFO
       type = log_type(args)
       return if skipped_type?(type)
-      args << block.call if block
+      args << yield if block_given?
       time, msg = event(:info, args)
       return if time.nil?
       puts [@color_info, @formatter.call(type, time, LEVEL_INFO, msg), @color_reset].join
@@ -373,11 +373,11 @@ module Fluent
       yield
     end
 
-    def warn(*args, &block)
+    def warn(*args)
       return if @level > LEVEL_WARN
       type = log_type(args)
       return if skipped_type?(type)
-      args << block.call if block
+      args << yield if block_given?
       time, msg = event(:warn, args)
       return if time.nil?
       puts [@color_warn, @formatter.call(type, time, LEVEL_WARN, msg), @color_reset].join
@@ -394,11 +394,11 @@ module Fluent
       yield
     end
 
-    def error(*args, &block)
+    def error(*args)
       return if @level > LEVEL_ERROR
       type = log_type(args)
       return if skipped_type?(type)
-      args << block.call if block
+      args << yield if block_given?
       time, msg = event(:error, args)
       return if time.nil?
       puts [@color_error, @formatter.call(type, time, LEVEL_ERROR, msg), @color_reset].join
@@ -415,11 +415,11 @@ module Fluent
       yield
     end
 
-    def fatal(*args, &block)
+    def fatal(*args)
       return if @level > LEVEL_FATAL
       type = log_type(args)
       return if skipped_type?(type)
-      args << block.call if block
+      args << yield if block_given?
       time, msg = event(:fatal, args)
       return if time.nil?
       puts [@color_fatal, @formatter.call(type, time, LEVEL_FATAL, msg), @color_reset].join

--- a/lib/fluent/plugin/buffer.rb
+++ b/lib/fluent/plugin/buffer.rb
@@ -650,7 +650,7 @@ module Fluent
       # 3. enqueue existing chunk & retry whole method if chunk was not empty
       # 4. go to step_by_step writing
 
-      def write_once(metadata, data, format: nil, size: nil, &block)
+      def write_once(metadata, data, format: nil, size: nil)
         return if data.empty?
 
         stored = false
@@ -701,7 +701,7 @@ module Fluent
           end
 
           if stored
-            block.call(chunk, adding_bytesize)
+            yield(chunk, adding_bytesize)
           end
         end
 
@@ -726,7 +726,7 @@ module Fluent
       # 2. append splits into the staged chunks as much as possible
       # 3. create unstaged chunk and append rest splits -> repeat it for all splits
 
-      def write_step_by_step(metadata, data, format, splits_count, &block)
+      def write_step_by_step(metadata, data, format, splits_count)
         splits = []
         if splits_count > data.size
           splits_count = data.size
@@ -855,7 +855,7 @@ module Fluent
           modified_chunks.last[:adding_bytesize] = chunk.bytesize - original_bytesize
         end
         modified_chunks.each do |data|
-          block.call(data[:chunk], data[:adding_bytesize], data[:errors])
+          yield(data[:chunk], data[:adding_bytesize], data[:errors])
         end
       rescue ShouldRetry
         modified_chunks.each do |data|

--- a/lib/fluent/plugin/in_forward.rb
+++ b/lib/fluent/plugin/in_forward.rb
@@ -239,7 +239,7 @@ module Fluent::Plugin
       end
     end
 
-    def read_messages(conn, &block)
+    def read_messages(conn)
       feeder = nil
       serializer = nil
       bytes = 0
@@ -250,7 +250,7 @@ module Fluent::Plugin
           if first == '{' || first == '[' # json
             parser = Yajl::Parser.new
             parser.on_parse_complete = ->(obj){
-              block.call(obj, bytes, serializer)
+              yield(obj, bytes, serializer)
               bytes = 0
             }
             serializer = :to_json.to_proc
@@ -260,7 +260,7 @@ module Fluent::Plugin
             serializer = :to_msgpack.to_proc
             feeder = ->(d){
               parser.feed_each(d){|obj|
-                block.call(obj, bytes, serializer)
+                yield(obj, bytes, serializer)
                 bytes = 0
               }
             }

--- a/lib/fluent/plugin/output.rb
+++ b/lib/fluent/plugin/output.rb
@@ -972,9 +972,9 @@ module Fluent
         end
       end
 
-      def write_guard(&block)
+      def write_guard
         begin
-          block.call
+          yield
         rescue Fluent::Plugin::Buffer::BufferOverflowError
           log.warn "failed to write data into buffer by buffer overflow", action: @buffer_config.overflow_action
           case @buffer_config.overflow_action

--- a/lib/fluent/plugin/parser_json.rb
+++ b/lib/fluent/plugin/parser_json.rb
@@ -93,10 +93,10 @@ module Fluent
         :text
       end
 
-      def parse_io(io, &block)
+      def parse_io(io)
         y = Yajl::Parser.new
         y.on_parse_complete = ->(record){
-          block.call(parse_time(record), record)
+          yield(parse_time(record), record)
         }
         y.parse(io, @stream_buffer_size)
       end

--- a/lib/fluent/plugin/storage_local.rb
+++ b/lib/fluent/plugin/storage_local.rb
@@ -158,8 +158,8 @@ module Fluent
         @store.delete(key.to_s)
       end
 
-      def update(key, &block)
-        @store[key.to_s] = block.call(@store[key.to_s])
+      def update(key)
+        @store[key.to_s] = yield(@store[key.to_s])
       end
     end
   end

--- a/lib/fluent/plugin_helper/compat_parameters.rb
+++ b/lib/fluent/plugin_helper/compat_parameters.rb
@@ -324,13 +324,13 @@ module Fluent
         conf
       end
 
-      def compat_parameters_copy_to_subsection_attributes(conf, params, &block)
+      def compat_parameters_copy_to_subsection_attributes(conf, params)
         hash = {}
         params.each do |compat, current|
           next unless current
           if conf.has_key?(compat)
             if block_given?
-              hash[current] = block.call(compat, conf[compat])
+              hash[current] = yield(compat, conf[compat])
             else
               hash[current] = conf[compat]
             end

--- a/lib/fluent/plugin_helper/formatter.rb
+++ b/lib/fluent/plugin_helper/formatter.rb
@@ -100,11 +100,11 @@ module Fluent
         end
       end
 
-      def formatter_operate(method_name, &block)
+      def formatter_operate(method_name)
         @_formatters.each_pair do |usage, formatter|
           begin
             formatter.__send__(method_name)
-            block.call(formatter) if block_given?
+            yield(formatter) if block_given?
           rescue => e
             log.error "unexpected error while #{method_name}", usage: usage, formatter: formatter, error: e
           end

--- a/lib/fluent/plugin_helper/parser.rb
+++ b/lib/fluent/plugin_helper/parser.rb
@@ -100,11 +100,11 @@ module Fluent
         end
       end
 
-      def parser_operate(method_name, &block)
+      def parser_operate(method_name)
         @_parsers.each_pair do |usage, parser|
           begin
             parser.__send__(method_name)
-            block.call(parser) if block_given?
+            yield(parser) if block_given?
           rescue => e
             log.error "unexpected error while #{method_name}", usage: usage, parser: parser, error: e
           end

--- a/lib/fluent/plugin_helper/storage.rb
+++ b/lib/fluent/plugin_helper/storage.rb
@@ -134,10 +134,10 @@ module Fluent
         end
       end
 
-      def storage_operate(method_name, &block)
+      def storage_operate(method_name)
         @_storages.each_pair do |usage, s|
           begin
-            block.call(s) if block_given?
+            yield(s) if block_given?
             s.storage.__send__(method_name)
           rescue => e
             log.error "unexpected error while #{method_name}", usage: usage, storage: s.storage, error: e
@@ -275,7 +275,7 @@ module Fluent
         def update(key, &block)
           @monitor.synchronize do
             @storage.load
-            v = block.call(@storage.get(key))
+            v = yield(@storage.get(key))
             @storage.put(key, v)
             @storage.save
             v
@@ -338,7 +338,7 @@ module Fluent
 
         def update(key, &block)
           @monitor.synchronize do
-            v = block.call(@storage.get(key))
+            v = yield(@storage.get(key))
             @storage.put(key, v)
             v
           end

--- a/lib/fluent/rpc.rb
+++ b/lib/fluent/rpc.rb
@@ -39,10 +39,10 @@ module Fluent
         @log.debug "register #{path} RPC servlet"
       end
 
-      def mount_proc(path, &block)
+      def mount_proc(path)
         @server.mount_proc(path) { |req, res|
           begin
-            code, header, response = block.call(req, res)
+            code, header, response = yield(req, res)
           rescue => e
             @log.warn "failed to handle RPC request", path: path, error: e.to_s
             @log.warn_backtrace e.backtrace

--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -1142,7 +1142,7 @@ module Fluent
       end
     end
 
-    def main_process(&block)
+    def main_process
       if @system_config.process_name
         if @system_config.workers > 1
           Process.setproctitle("worker:#{@system_config.process_name}#{ENV['SERVERENGINE_WORKER_ID']}")
@@ -1154,7 +1154,7 @@ module Fluent
       unrecoverable_error = false
 
       begin
-        block.call
+        yield
       rescue Fluent::ConfigError => e
         logging_with_console_output do |log|
           log.error "config error", file: @config_path, error: e

--- a/lib/fluent/test/driver/base.rb
+++ b/lib/fluent/test/driver/base.rb
@@ -185,7 +185,7 @@ module Fluent
           end
         end
 
-        def run_actual(timeout: DEFAULT_TIMEOUT, &block)
+        def run_actual(timeout: DEFAULT_TIMEOUT)
           if @instance.respond_to?(:_threads)
             sleep 0.1 until @instance._threads.values.all?(&:alive?)
           end
@@ -201,7 +201,7 @@ module Fluent
           return_value = nil
           begin
             Timeout.timeout(timeout * 2) do |sec|
-              return_value = block.call if block_given?
+              return_value = yield if block_given?
             end
           rescue Timeout::Error
             raise TestTimedOut, "Test case timed out with hard limit."

--- a/lib/fluent/test/filter_test.rb
+++ b/lib/fluent/test/filter_test.rb
@@ -59,9 +59,9 @@ module Fluent
       alias_method :emits, :filtered_as_array # emits is for consistent with other drivers
 
       # Almost filters don't use threads so default is 0. It reduces test time.
-      def run(num_waits = 0, &block)
+      def run(num_waits = 0)
         super(num_waits) {
-          block.call if block
+          yield if block_given?
 
           @events.each { |tag, es|
             processed = @instance.filter_stream(tag, es)

--- a/lib/fluent/test/input_test.rb
+++ b/lib/fluent/test/input_test.rb
@@ -109,7 +109,7 @@ module Fluent
         end
       end
 
-      def run(num_waits = 10, &block)
+      def run(num_waits = 10)
         m = method(:emit_stream)
         unless Engine.singleton_class.ancestors.include?(EmitStreamWrapper)
           Engine.singleton_class.prepend EmitStreamWrapper
@@ -121,7 +121,7 @@ module Fluent
         instance.router.emit_stream_callee = m
 
         super(num_waits) {
-          block.call if block
+          yield if block_given?
 
           if @expected_emits_length || @expects || @run_post_conditions
             # counters for emits and emit_streams

--- a/lib/fluent/test/output_test.rb
+++ b/lib/fluent/test/output_test.rb
@@ -71,10 +71,10 @@ module Fluent
         (@expected_buffer ||= '') << str
       end
 
-      def run(num_waits = 10, &block)
+      def run(num_waits = 10)
         result = nil
         super(num_waits) {
-          block.call if block
+          yield if block_given?
 
           es = ArrayEventStream.new(@entries)
           buffer = @instance.format_stream(@tag, es)
@@ -119,10 +119,10 @@ module Fluent
         (@expected_buffer ||= '') << str
       end
 
-      def run(&block)
+      def run
         result = []
         super {
-          block.call if block
+          yield if block_given?
 
           buffer = ''
           lines = {}


### PR DESCRIPTION
This is cosmetic change, it does not change behavior at all. The following rubocop configuration detects it.

```
Performance/RedundantBlockCall:
  Enable: true
```

Benchmark result:

```
ruby 3.2.8 (2025-03-26 revision 13f495dc2c) +YJIT [x86_64-linux]
Warming up --------------------------------------
          block call     1.296M i/100ms
   yield with &block     1.708M i/100ms
yield without &block     1.687M i/100ms
Calculating -------------------------------------
          block call     12.964M (± 0.8%) i/s   (77.14 ns/i) -     66.097M in   5.098814s
   yield with &block     17.186M (± 0.5%) i/s   (58.19 ns/i) -     87.092M in   5.067659s
yield without &block     17.162M (± 0.3%) i/s   (58.27 ns/i) -     86.062M in   5.014579s

Comparison:
   yield with &block: 17186340.4 i/s
yield without &block: 17162477.2 i/s - same-ish: difference falls within error
          block call: 12964086.6 i/s - 1.33x  slower
```

yield with/without &block is same-ish. For simplicity, use without &block.

Appendix: benchmark script

```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
  gem 'benchmark-memory'
end

def block_call(s, &block)
  block.call(s) if block_given?
end

def yield_with_block(s, &block)
  yield(s) if block_given?
end

def yield_without_block(s)
  yield(s) if block_given?
end

Benchmark.ips do |x|
  x.report("block call") {
    block_call("dummy") do |message|
      message
    end
  }
  x.report("yield with &block") {
    yield_with_block("dummy") do |message|
      message
    end
  }
  x.report("yield without &block") {
    yield_without_block("dummy") do |message|
      message
    end
  }
  x.compare!
end
```

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

**Docs Changes**:

**Release Note**: 
