### PR TITLE
github: introduce RuboCop minimum rules

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,42 @@
+name: RucoCop
+
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      - '*.md'
+      - 'lib/fluent/version.rb'
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - '*.md'
+      - 'lib/fluent/version.rb'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['3.4']
+    name: Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@a4effe49ee8ee5b8b5091268c473a4628afb5651 # v1.245.0
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+      - name: Install dependencies
+        run: |
+          bundle install
+          gem install benchmark-ips
+      - name: Run RuboCop
+        run: rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,115 @@
+plugins:
+  - rubocop-performance
+
+AllCops:
+  Exclude:
+    - 'vendor/**/*'
+  NewCops: enable
+  SuggestExtensions: false
+  TargetRubyVersion: 3.4
+
+#
+# Policy: Check Security & Performance in primary use-cases
+# (Disable most of cosmetic rules)
+#
+
+Lint:
+  Enabled: false
+
+Style:
+  Enabled: false
+
+Gemspec:
+  Enabled: false
+
+Naming:
+  Enabled: false
+
+Layout:
+  Enabled: false
+
+Metrics:
+  Enabled: false
+
+Security:
+  Enabled: true
+
+Performance:
+  Enabled: true
+
+#
+# False positive or exceptional cases
+#
+
+# False positive because it's intentional
+Security/Open:
+  Exclude:
+    - lib/fluent/plugin/buffer/chunk.rb
+  Enabled: true
+
+# False positive because it's intentional
+Security/Eval:
+  Exclude:
+    - lib/fluent/plugin.rb
+    - lib/fluent/plugin/in_debug_agent.rb
+  Enabled: true
+
+# False positive because send method must accept literals.
+Performance/StringIdentifierArgument:
+  Exclude:
+    - test/plugin/test_in_tcp.rb
+    - test/plugin/test_in_udp.rb
+    - test/counter/test_server.rb
+    - test/plugin/test_out_forward.rb
+    - lib/fluent/plugin/out_forward.rb
+  Enabled: true
+
+Performance/StringInclude:
+  Exclude:
+    - 'test/**/*'
+    # It was not improved with String#include?
+    - lib/fluent/command/plugin_config_formatter.rb
+  Enabled: true
+
+# False positive for include? against constant ranges.
+# Almost same between include? and cover?.
+# See https://github.com/rubocop/rubocop-jp/issues/20
+Performance/RangeInclude:
+   Exclude:
+     - lib/fluent/plugin/parser_multiline.rb
+   Enabled: true
+
+# Allow using &method(:func)
+Performance/MethodObjectAsBlock:
+  Exclude:
+    - 'test/**/*'
+  Enabled: false
+
+# Allow block.call
+Performance/RedundantBlockCall:
+  Exclude:
+    - 'test/**/*'
+    - 'lib/fluent/plugin_helper/*.rb'
+    - 'lib/fluent/plugin/*.rb'
+    - 'lib/fluent/compat/*.rb'
+    - 'lib/fluent/config/*.rb'
+    - 'lib/fluent/*.rb'
+  Enabled: true
+
+#
+# TODO: low priority to be fixed
+#
+Performance/ConstantRegexp:
+   Exclude:
+     - 'test/**/*'
+   Enabled: true
+
+Performance/Sum:
+  Exclude:
+    - 'test/**/*'
+  Enabled: true
+
+Performance/CollectionLiteralInLoop:
+  Exclude:
+    - 'test/**/*'
+  Enabled: true


### PR DESCRIPTION
Guard code regression such as follows:

  Offenses:

  test/plugin/test_buf_file.rb:26:29: C: [Correctable] Performance/StringIdentifierArgument: Use :@write instead of "@write".
        instance_variable_set("@write", block)
                              ^^^^^^^^
  test/plugin/test_buf_file_single.rb:43:29: C: [Correctable] Performance/StringIdentifierArgument: Use :@write instead of "@write".
        instance_variable_set("@write", block)
                              ^^^^^^^^

<!--
Thank you for contributing to Fluentd!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

**Which issue(s) this PR fixes**: 
Fixes #

**What this PR does / why we need it**: 

**Docs Changes**:

**Release Note**: 
